### PR TITLE
Add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+
+      - run: go build ./...
+      - run: go vet ./...
+      - run: go test ./... -short -race


### PR DESCRIPTION
## Summary
- Add `.github/workflows/ci.yml` with build, vet, and race-enabled test steps
- Triggers on push to main and on pull requests
- Uses Go 1.26 matching `go.mod`

## Test plan
- [ ] Verify the workflow triggers on this PR
- [ ] Confirm `go build`, `go vet`, and `go test -race` steps pass